### PR TITLE
Fix cross dependency check function

### DIFF
--- a/src/validators/_test_/cross_setting_test.js
+++ b/src/validators/_test_/cross_setting_test.js
@@ -36,11 +36,12 @@ describe('cross setting validation', function() {
     it('returns an error when a setting is not referenced before it is resolved', function() {
         var report;
 
-        this.config[1].except.setting = 'settingC';
+        this.config[0].except = [{setting: 'settingC', value: false}];
 
         report = validate(this.clientSchema, this.config);
 
-        expect(report.errors[0].message).to.equal('Setting `settingC` was referenced before it was resolved.');
+        expect(report.errors[0].message).to.equal('For settingA, your dependency `settingC` was referenced before it' +
+        ' was resolved. Move the definition of it above settingA');
         expect(report.valid).to.be.false;
     });
 
@@ -50,18 +51,19 @@ describe('cross setting validation', function() {
         // i'm writing this test.
         var report;
 
-        this.config[1].except.setting = 'settingC';
+        this.config[1].except[0].setting = 'settingC';
 
         report = validate(this.clientSchema, this.config);
 
-        expect(report.errors[0].message).to.equal('Setting `settingC` was referenced before it was resolved.');
+        expect(report.errors[0].message).to.equal('For settingB, your dependency `settingC` was referenced before it' +
+        ' was resolved. Move the definition of it above settingB');
         expect(report.valid).to.be.false;
     });
 
     it('returns an error when the setting depends on itself', function() {
         var report;
 
-        this.config[1].except.setting = 'settingB';
+        this.config[1].except[0].setting = 'settingB';
 
         report = validate(this.clientSchema, this.config);
 

--- a/src/validators/_test_/schema_test.js
+++ b/src/validators/_test_/schema_test.js
@@ -728,6 +728,9 @@ describe('schema validation', function() {
     describe('feature dependency check', function() {
         beforeEach(function() {
             this.data = [{
+                setting: 'someFeature',
+                value: false
+            }, {
                 setting: 'setting',
                 value: false,
                 except: []
@@ -739,7 +742,7 @@ describe('schema validation', function() {
         it('does not return an error when `setting` is a string', function() {
             var report;
 
-            this.data[0].except.push({
+            this.data[1].except.push({
                 value: true,
                 setting: 'someFeature'
             });
@@ -750,14 +753,14 @@ describe('schema validation', function() {
         });
 
         it('returns an error when `setting` is not a string', function() {
-            this.data[0].except.push({
+            this.data[1].except.push({
                 value: true
             });
 
             [true, 42, {}, []].forEach(function(valType) {
                 var report;
 
-                this.data[0].except.setting = valType;
+                this.data[1].except[0].setting = valType;
 
                 report = validate(this.clientSchema, this.data);
                 expect(report.valid).to.be.false;

--- a/src/validators/index.js
+++ b/src/validators/index.js
@@ -91,22 +91,29 @@ function _validateCrossSettingDependencies(configuration) {
         errors = [];
 
     configuration.forEach(function(entry) {
-        var dependencyName = entry.except && entry.except.setting;
+        var dependencies = entry.except;
 
-        if (dependencyName) {
-            // if an entry depends on itself, error
-            if (dependencyName === entry.setting) {
-                errors.push({
-                    message: 'Setting `' + dependencyName + '` depends on itself.'
-                });
-            }
+        if (Array.isArray(dependencies)) {
+            dependencies.forEach(dependency => {
+                var dependencyName = dependency.setting;
 
-            // if an entry has not been referenced yet, error
-            if (!existingSettings.hasOwnProperty(dependencyName)) {
-                errors.push({
-                    message: 'Setting `' + dependencyName + '` was referenced before it was resolved.'
-                });
-            }
+                if (dependencyName) {
+                    // if an entry depends on itself, error
+                    if (dependencyName === entry.setting) {
+                        errors.push({
+                            message: 'Setting `' + dependencyName + '` depends on itself.'
+                        });
+                    }
+
+                    // if an entry has not been referenced yet, error
+                    if (!existingSettings.hasOwnProperty(dependencyName)) {
+                        errors.push({
+                            message: 'For ' + entry.setting + ', your dependency `' + dependencyName +
+                            '` was referenced before it was resolved. Move the definition of it above ' + entry.setting
+                        });
+                    }
+                }
+            });
         }
 
         // add it to the list of settings that exists


### PR DESCRIPTION
This PR Adds order validation during resolving process. When resolving the settings' values, a setting's dependency must be defined and resolved first before it can be referred.

P.S. This is duplicate of this: https://git.ouroath.com/Mail/cerebro/pull/71.
I updated the wrong repo. 
@juandopazo Can you help merge this? Thanks