### PR TITLE
Introduce labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,28 @@ The `dimensionValue` would be [“en”], and the testValue would be whatever th
 ## Overrides
 We may want to override a certain setting, regardless of what the configuration says.  To do this, the client must pass an object, `overrides`, into the Cerebro constructor.  The keys of the `overrides` object will be the setting names and the value will be the value of the setting.  Typically, these overrides would come from the request URL, but any source can be used.
 
+### Labels
+Label metadata may be added to each entry in the form of an array of strings.  This does not affect the evaluation of setting entries into their resulting values.  It's stricly meant as a way to contextualize those values.  
+
+For instance, values that are not wanted as part of a client payload can be marked "server".  
+
+Note that this could be used to create subsets of values that no longer have all of the original entries with contraints such as dependencies.  
+
+An alternative way to organize and contextualize is to group settings into separate files.
+
+
+```js
+[{
+    setting: 'enableNewFeature',
+    labels: ['server', 'namedFeatureGroup'],
+    value: false,
+    except: [{
+        value: true,
+        partialLocale: ['en']
+    }]
+}]
+```
+
 ## Thanks
 
 * Many thanks to Alasdair Mercer for donating the naming rights :) 

--- a/src/_test_/index_test.js
+++ b/src/_test_/index_test.js
@@ -15,7 +15,7 @@ require('../../test/setup/server');
 describe('./index.js', function() {
     beforeEach(function() {
         this.config = [{a: 1}];
-        this.tags = {a: ['s'], b: ['c'], c: ['s', 'c']};
+        this.labels = {a: ['s'], b: ['c'], c: ['s', 'c']};
         this.context = {b: 2};
         this.overrides = {c: 3};
         this.options = {
@@ -63,50 +63,50 @@ describe('./index.js', function() {
         });
 
         describe('#resolveConfig', function() {
-            it('returns tags when defined', function() {
-                var tagEntries = this.tags;
+            it('returns labels when defined', function() {
+                var labelEntries = this.labels;
                 var config = this.config.map(function(e) {
                     var setting = Object.keys(e)[0];
                     var value = e[setting];
-                    var tags = tagEntries[setting] || [];
+                    var labels = labelEntries[setting] || [];
 
-                    return {setting, value, tags};
+                    return {setting, value, labels};
                 });
                 var resolved = config.reduce(function(s, e) {
                     return Object.assign({}, {[e.setting]: e.value});
                 }, {});
-                var expectedTags = config.reduce(function(s, e) {
-                    return Object.assign({}, {[e.setting]: e.tags});
+                var expectedLabels = config.reduce(function(s, e) {
+                    return Object.assign({}, {[e.setting]: e.labels});
                 }, {});
                 var options = {};
                 var cerebro = new Cerebro(config, options);
                 var actualConfig = cerebro.resolveConfig({});
 
                 expect(actualConfig._resolved).to.deep.equal(resolved);
-                expect(actualConfig._tags).to.deep.equal(expectedTags);
+                expect(actualConfig._labels).to.deep.equal(expectedLabels);
             });
 
-            it('returns no tags when not defined', function() {
-                var tagEntries = {};
+            it('returns no labels when not defined', function() {
+                var labelEntries = {};
                 var config = this.config.map(function(e) {
                     var setting = Object.keys(e)[0];
                     var value = e[setting];
-                    var tags = tagEntries[setting] || [];
+                    var labels = labelEntries[setting] || [];
 
-                    return {setting, value, tags};
+                    return {setting, value, labels};
                 });
                 var resolved = config.reduce(function(s, e) {
                     return Object.assign({}, {[e.setting]: e.value});
                 }, {});
-                var tags = config.reduce(function(s, e) {
-                    return Object.assign({}, {[e.setting]: e.tags});
+                var labels = config.reduce(function(s, e) {
+                    return Object.assign({}, {[e.setting]: e.labels});
                 }, {});
                 var options = {};
                 var cerebro = new Cerebro(config, options);
                 var actualConfig = cerebro.resolveConfig({});
 
                 expect(actualConfig._resolved).to.deep.equal(resolved);
-                expect(actualConfig._tags).to.deep.equal(tags);
+                expect(actualConfig._labels).to.deep.equal(labels);
             });
 
             it('throws an error if context is not passed', function() {
@@ -151,13 +151,13 @@ describe('./index.js', function() {
         beforeEach(function() {
             var cerebro = new Cerebro([]),
                 rawConfig = {a: 111, b: true, c: {multilevel: [1, 2]}},
-                tags = {a: ['s'], b: ['c'], c: ['s', 'c']};
+                labels = {a: ['s'], b: ['c'], c: ['s', 'c']};
 
             this.sandbox.stub(Cerebro.prototype, '_build', function() {
-                return {answers: rawConfig, tags};
+                return {answers: rawConfig, labels};
             });
             this.rawConfig = rawConfig;
-            this.tags = tags;
+            this.labels = labels;
             this.cerebroConfig = cerebro.resolveConfig({});
         });
 
@@ -205,11 +205,11 @@ describe('./index.js', function() {
             });
         });
 
-        describe('#getTags', function() {
-            it('returns tagged config used in constructor', function() {
-                var actualConfig = this.cerebroConfig.getTags();
+        describe('#getLabels', function() {
+            it('returns labeled config used in constructor', function() {
+                var actualConfig = this.cerebroConfig.getLabels();
 
-                expect(actualConfig).to.deep.equal(this.tags);
+                expect(actualConfig).to.deep.equal(this.labels);
             });
         });
 
@@ -219,7 +219,7 @@ describe('./index.js', function() {
 
                 expect(json).to.equal(JSON.stringify({
                     _resolved: this.rawConfig,
-                    _tags: this.tags
+                    _labels: this.labels
                 }));
             });
         });

--- a/src/index.js
+++ b/src/index.js
@@ -50,10 +50,10 @@ Cerebro.rehydrate = function(dehydratedObject) {
     // if the dehydratedObject is not valid, JSON parse will fail and throw an error
     var rehydratedObj = JSON.parse(dehydratedObject);
 
-    const {_resolved, _tags} = rehydratedObj;
+    const {_resolved, _labels} = rehydratedObj;
     const builtObject = {
         answers: _resolved,
-        tags: _tags
+        labels: _labels
     };
 
     return new CerebroConfig(builtObject);
@@ -70,7 +70,7 @@ function CerebroConfig(resolvedConfig = {}) {
     }
 
     this._resolved = resolvedConfig.answers;
-    this._tags = resolvedConfig.tags;
+    this._labels = resolvedConfig.labels;
 }
 
 /**
@@ -125,8 +125,8 @@ CerebroConfig.prototype.getValue = function(name) {
  * @return {JSON} Map of settings to values.
  */
 CerebroConfig.prototype.dehydrate = function() {
-    const {_resolved, _tags} = this;
-    const dehydratedObject = {_resolved, _tags};
+    const {_resolved, _labels} = this;
+    const dehydratedObject = {_resolved, _labels};
 
     return JSON.stringify(dehydratedObject);
 };
@@ -143,12 +143,14 @@ CerebroConfig.prototype.getRawConfig = function() {
 };
 
 /**
- * Returns the tags from the entries
+ * Returns the labels from the entries
  *
- * @return {Object} The tags.
+ * @return {Object} The labels as an object just like getRawConfig,
+ * where each key is setting name and its value is an array of string labels.
+ * Entries with no labels are represented as an empty array (not undefined).
  */
-CerebroConfig.prototype.getTags = function() {
-    return this._tags;
+CerebroConfig.prototype.getLabels = function() {
+    return this._labels;
 };
 
 /** @private */
@@ -162,7 +164,7 @@ Cerebro.prototype._preprocess = function(config) {
 /** @private */
 Cerebro.prototype._build = function(context, overrides) {
     var answers = {},
-        tags = {},
+        labels = {},
         answer;
 
     this._config.forEach(function(entry) {
@@ -171,14 +173,14 @@ Cerebro.prototype._build = function(context, overrides) {
         if (answer.key) {
             if (!answers.hasOwnProperty(answer.key)) {
                 answers[answer.key] = answer.value;
-                tags[answer.key] = entry.tags || [];
+                labels[answer.key] = entry.labels || [];
             }
         }
     }, this);
 
     return {
         answers,
-        tags
+        labels
     };
 };
 

--- a/src/validators/schema.json
+++ b/src/validators/schema.json
@@ -8,6 +8,12 @@
             "setting": {
                 "type": "string"
             },
+            "tags": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            },
             "value": {
                 "type" : ["string", "number", "boolean", "object", "array"],
                 "additionalProperties": true

--- a/src/validators/schema.json
+++ b/src/validators/schema.json
@@ -8,7 +8,7 @@
             "setting": {
                 "type": "string"
             },
-            "tags": {
+            "labels": {
                 "type": "array",
                 "items": {
                     "type": "string"


### PR DESCRIPTION
We need a way to filter-out certain entries that are used exclusively on the server-side and would just be bloat if sent with the rest of the config payload to the client.

We could have used a custom evaluator, but the yaml for that would have been more complicated.  For each entry, would've been something like:
```
# Feature flipper for doing something
- setting: someRandomSetting
  value: false
  except:
    - value: undefined
      serverSideSetting:
        evaluator: serverSideEvaluator
        dimensionValue:
          - attribute: environment
            test: includes
            args:
              - server
```
nor did I want to do something inflexible that hardCoded the presumption of server-side and client-side, such as:
```
# Feature flipper for doing something
- setting: someRandomSetting
  value: false
  serverSideOnly: true
```
so I wrote a tag system which I think is a good balance between complexity and flexibility.
```
# Feature flipper for doing something
- setting: someRandomSetting
  value: false
  tags: ["server"]
```
where the constructor of Cerebro can pass-in a tag evaluator (along with any of the more complex custom evaluators) defined perhaps like this:
```
const includesServerRegex = /server.*/i;
const tagEvaluator = tags => !(tags && tags.some(tag => includesServerRegex.test(tag)));
const cerebro = new Cerebro(config, {
    customEvaluators: {
        udbEvaluator,
        mailboxAttributesEvaluator,
        athenaEvaluator,
        commonEvaluator
    },
    tagEvaluator
});
```
then when we need just the entries that meet the tag requirements (in our case, entries we want on the client-side, as our tag evaluator filters-out those marked server), we can call:
```
cerebro.getTaggedConfig()
```
and can still call:
```
config.getRawConfig())
```
when we want all the config data (like on the server).
