### PR TITLE
Update dev deps to fix audit issues, update typescript defs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,7 +21,8 @@ declare namespace Cerebro {
     customEvaluators?: { [key: string]: Function }
   }
   interface ICerebroContext {
-    percentageSeed: string | number
+    percentageSeed?: string | number
+    [key: string]: any
   }
   interface ICerebroConfigOptions {
     overrides?: { [key: string]: any }

--- a/package.json
+++ b/package.json
@@ -11,14 +11,14 @@
   },
   "devDependencies": {
     "chai": "^4.1.0",
-    "coveralls": "^2.13.1",
+    "coveralls": "^3.0.4",
     "grunt": "~1.0.1",
     "grunt-benchmark": "~1.0.0",
     "grunt-cli": "~1.2.0",
     "grunt-eslint": "^20.0.0",
     "grunt-mocha-istanbul": "^5.0.2",
     "istanbul": "^0.4.5",
-    "mocha": "^3.2.0",
+    "mocha": "^6.1.4",
     "phantomjs-prebuilt": "~2.1.13",
     "sinon": "~1.17.6",
     "sinon-chai": "^2.11.0"


### PR DESCRIPTION
- The typescript def for `ICerebroContext` lacks the ability to specify additional keys; this has been updated (and tested locally on our own installation)
- `ICerebroContext.percentageSeed` has been marked optional (we've never explicitly defined the parameter without issues, and it seems specific to the internal `Evaluator` the project has)
- `package.json` dev deps has been updated to fix `npm audit` issues. Tests execute without problems, along with coverage report details

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
