### PR TITLE
Polling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 sudo: false
 language: node_js
 node_js:
-  - 7
-  - 6
+  - lts/*
 after_success: 'npm run coveralls'

--- a/README.md
+++ b/README.md
@@ -251,6 +251,30 @@ An alternative way to organize and contextualize is to group settings into separ
 }]
 ```
 
+### Configuration polling
+
+This option is useful for having live configuration that updates without having to re-deploy your application. A poller object continuously calls a `fetch` function to retrieve a newer version of the configuration. This is very open ended to allow for different security mechanisms such as mTLS or signed responses.
+
+Optionally (but recommended), a configuration schema can be given to the poller to ensure that the response is a valid configuration.
+
+```js
+const Cerebro = require('cerebro');
+
+const poller = new Cerebro.ConfigPoller({
+  clientSchema: /* optional schema */,
+  interval: 5000,
+  fetch: async function() {
+    const response = await fetch(/* ... */);
+
+    return response.json();
+  }
+});
+
+const cerebro = new Cerebro(config, {
+  poller
+});
+```
+
 ## Thanks
 
 * Many thanks to Alasdair Mercer for donating the naming rights :) 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cerebro",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "A generic configuration system for Node.js.",
   "author": "Scott Sperling <scsper@yahoo.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "istanbul": "^0.4.5",
     "mocha": "^6.1.4",
     "phantomjs-prebuilt": "~2.1.13",
-    "sinon": "~1.17.6",
-    "sinon-chai": "^2.11.0"
+    "sinon": "^12.0.1",
+    "sinon-chai": "^3.7.0"
   },
   "dependencies": {
     "buffer-crc32": "^0.2.13",

--- a/src/_test_/config_poller_test.js
+++ b/src/_test_/config_poller_test.js
@@ -1,0 +1,191 @@
+/**
+ * Copyright 2017 Yahoo Holdings Inc.
+ * Licensed under the terms of the MIT license. See LICENSE file in project root for terms.
+ */
+
+/* eslint-env mocha */
+/* eslint-disable no-unused-expressions */
+
+const expect = require('chai').expect;
+const ConfigPoller = require('../config_poller');
+
+require('../../test/setup/server');
+
+describe('config_poller.js', function() {
+    beforeEach(function() {
+        this.clock = this.sandbox.useFakeTimers();
+    });
+
+    it('throws a TypeError when not receiving an interval', function() {
+        expect(() => new ConfigPoller({
+            fetch: () => Promise.resolve(true)
+        })).to.throw(TypeError);
+    });
+
+    it('throws a TypeError when not receiving a fetch function', function() {
+        expect(() => new ConfigPoller({
+            interval: 5000
+        })).to.throw(TypeError);
+    });
+
+    it('calls the fetch function on the interval', function() {
+        const fetch = this.sandbox.stub().returns(Promise.resolve(1));
+        const poller = new ConfigPoller({
+            fetch,
+            interval: 5000
+        });
+
+        poller.start();
+
+        expect(fetch).not.to.have.been.called;
+
+        this.clock.tick(5000);
+
+        expect(fetch).to.have.been.calledOnce;
+    });
+
+    it('fires an error event when fetching goes wrong', function(done) {
+        const poller = new ConfigPoller({
+            fetch: function() {
+                return Promise.reject(new Error('foo'));
+            },
+            interval: 5000
+        });
+
+        poller.on('error', error => {
+            expect(error).to.be.instanceOf(Error);
+            done();
+        });
+
+        poller.start();
+
+        this.clock.tick(5000);
+    });
+
+    it('fires an error event when the response is empty', function(done) {
+        const poller = new ConfigPoller({
+            fetch: function() {
+                return Promise.resolve('');
+            },
+            interval: 5000
+        });
+
+        poller.on('error', error => {
+            expect(error).to.be.instanceOf(Error);
+            done();
+        });
+
+        poller.start();
+
+        this.clock.tick(5000);
+    });
+
+    it('fires an error event when the response fails the schema validation', function(done) {
+        const clientSchema = {
+            os: {
+                type: 'array',
+                minItems: 1,
+                uniqueItems: true,
+                items: {
+                    type: 'string',
+                    enum: [
+                        'ios',
+                        'android',
+                        'windows',
+                        'mac',
+                        'other'
+                    ]
+                }
+            }
+        };
+        const poller = new ConfigPoller({
+            clientSchema,
+            fetch: function() {
+                return Promise.resolve([
+                    {
+                        setting: 'test',
+                        value: true,
+                        except: [{
+                            value: false,
+                            os: ['unknown os']
+                        }]
+                    }
+                ]);
+            },
+            interval: 5000
+        });
+
+        poller.on('error', error => {
+            expect(error).to.be.instanceOf(Error);
+            done();
+        });
+
+        poller.start();
+
+        this.clock.tick(5000);
+    });
+
+    it('fires an update event when fetching succeeds without a schema', function(done) {
+        const poller = new ConfigPoller({
+            fetch: function() {
+                return Promise.resolve([]);
+            },
+            interval: 5000
+        });
+
+        poller.on('update', result => {
+            expect(result).to.be.instanceOf(Array);
+            done();
+        });
+
+        poller.start();
+
+        this.clock.tick(5000);
+    });
+
+    it('fires an update event when fetching succeeds with a schema', function(done) {
+        const clientSchema = {
+            os: {
+                type: 'array',
+                minItems: 1,
+                uniqueItems: true,
+                items: {
+                    type: 'string',
+                    enum: [
+                        'ios',
+                        'android',
+                        'windows',
+                        'mac',
+                        'other'
+                    ]
+                }
+            }
+        };
+        const newConfig = [
+            {
+                setting: 'test',
+                value: true,
+                except: [{
+                    value: false,
+                    os: ['android']
+                }]
+            }
+        ];
+        const poller = new ConfigPoller({
+            clientSchema,
+            fetch: function() {
+                return Promise.resolve(newConfig);
+            },
+            interval: 5000
+        });
+
+        poller.on('update', result => {
+            expect(result).to.deep.equal(newConfig);
+            done();
+        });
+
+        poller.start();
+
+        this.clock.tick(5000);
+    });
+});

--- a/src/config_poller.js
+++ b/src/config_poller.js
@@ -1,0 +1,51 @@
+/* eslint-disable no-console */
+const events = require('events');
+const os = require('os');
+const validate = require('./validators');
+
+const EventEmitter = events.EventEmitter;
+
+class ConfigPoller extends EventEmitter {
+    constructor(options = {}) {
+        super();
+
+        if (!options.interval || typeof options.interval !== 'number') {
+            throw new TypeError('Expected options.interval to be a number but got a ' + typeof options.interval);
+        }
+
+        if (typeof options.fetch !== 'function') {
+            throw new TypeError('Expected options.poller to be an async function but got a ' + typeof options.poller);
+        }
+
+        this.interval = options.interval;
+        this.fetch = options.fetch;
+        this.clientSchema = options.clientSchema;
+    }
+
+    start() {
+        setInterval(() => this.poll(), this.interval);
+    }
+
+    poll() {
+        this.fetch().then(result => {
+            if (!result) {
+                throw new Error('Unexpected empty configuration');
+            }
+
+            if (this.clientSchema) {
+                const validationReport = validate(this.clientSchema, result);
+
+                if (!validationReport.valid) {
+                    throw new Error('Invalid configuration received: ' + validationReport.errors.join(os.EOL));
+                }
+            }
+
+            this.emit('update', result);
+        }).catch(error => {
+            this.emit('error', error);
+        });
+
+    }
+}
+
+module.exports = ConfigPoller;

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@
  */
 
 var Evaluator = require('./evaluator.js');
+const ConfigPoller = require('./config_poller');
 
 /**
  * @param {Array} config - array containing setting entries
@@ -19,6 +20,15 @@ function Cerebro(config, options) {
     this._customEvaluators = options && options.customEvaluators;
 
     this._validateCustomEvaluators();
+
+    const poller = options && options.poller;
+
+    if (poller) {
+        poller.on('update', config => {
+            this._handleConfigUpdate(config);
+        });
+        poller.start();
+    }
 }
 
 /**
@@ -36,6 +46,10 @@ Cerebro.prototype.resolveConfig = function(context, options) {
     options = options || {};
 
     return new CerebroConfig(this._build(context, options.overrides));
+};
+
+Cerebro.prototype._handleConfigUpdate = function(config) {
+    this._config = this._preprocess(config);
 };
 
 /**
@@ -58,6 +72,8 @@ Cerebro.rehydrate = function(dehydratedObject) {
 
     return new CerebroConfig(builtObject);
 };
+
+Cerebro.ConfigPoller = ConfigPoller;
 
 /**
  * Wrapper for resolvedConfig that provides convenience methods for checking value types and dehydration

--- a/test/setup/server.js
+++ b/test/setup/server.js
@@ -7,7 +7,7 @@ var sinon = require('sinon');
 chai.use(sinonChai);
 
 beforeEach(function() {
-    this.sandbox = sinon.sandbox.create();
+    this.sandbox = sinon.createSandbox();
 });
 
 afterEach(function() {


### PR DESCRIPTION
This introduces a way to continuously poll for new configuration. This allows for configuration to be changed while the application is running. New API:

```js
const Cerebro = require('cerebro');

const poller = new Cerebro.ConfigPoller({
  clientSchema: /* optional schema */,
  interval: 5000,
  fetch: async function() {
    const response = await fetch(/* ... */);

    return response.json();
  }
});

const cerebro = new Cerebro(config, {
  poller
});
```

cc @reid
